### PR TITLE
by primsi: add name property to composer.json.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,5 @@
 {
+  "name": "drupal-contrib:media_entity_twitter",
   "require": {
     "j7mbo/twitter-api-php": "dev-master"
   }


### PR DESCRIPTION
As there is no policy yet, the name might be temporary (see: https://www.drupal.org/node/2401519).
