### PR TITLE
Provide the Tweet bundle by default

### DIFF
--- a/config/install/field.field.media.tweet.tweet.yml
+++ b/config/install/field.field.media.tweet.tweet.yml
@@ -1,0 +1,18 @@
+langcode: und
+status: true
+dependencies:
+  config:
+    - field.storage.media.tweet
+    - media_entity.bundle.tweet
+id: media.tweet.tweet
+field_name: tweet
+entity_type: media
+bundle: tweet
+label: Tweet
+description: "Paste tweet's URL or embed code."
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/install/field.storage.media.tweet.yml
+++ b/config/install/field.storage.media.tweet.yml
@@ -1,0 +1,17 @@
+langcode: und
+status: true
+dependencies:
+  module:
+    - media_entity
+id: media.tweet
+field_name: tweet
+entity_type: media
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false

--- a/config/install/media_entity.bundle.tweet.yml
+++ b/config/install/media_entity.bundle.tweet.yml
@@ -1,0 +1,13 @@
+langcode: und
+status: true
+dependencies:
+  module:
+    - media_entity_twitter
+id: tweet
+label: Tweet
+description: 'Represents a tweet.'
+type: twitter
+type_configuration:
+  source_field: tweet
+  use_twitter_api: 0
+field_map: {  }


### PR DESCRIPTION
People will want a sensible default for the Tweet media entity bundle; this PR pulls the tweet bundle out of Media Pinkeye.
