### PR TITLE
entity->value is null if we use Link field for tweet URL

### DIFF
--- a/src/Plugin/Validation/Constraint/TweetEmbedCodeConstraintValidator.php
+++ b/src/Plugin/Validation/Constraint/TweetEmbedCodeConstraintValidator.php
@@ -24,7 +24,7 @@ class TweetEmbedCodeConstraintValidator extends ConstraintValidator {
       return;
     }
 
-    if (preg_match(Twitter::VALIDATION_REGEXP, $entity->value)) {
+    if (preg_match(Twitter::VALIDATION_REGEXP, $entity->uri)) {
       return;
     }
 

--- a/src/Plugin/Validation/Constraint/TweetVisibleConstraintValidator.php
+++ b/src/Plugin/Validation/Constraint/TweetVisibleConstraintValidator.php
@@ -53,7 +53,7 @@ class TweetVisibleConstraintValidator extends ConstraintValidator implements Con
     }
 
     $matches = [];
-    preg_match(Twitter::VALIDATION_REGEXP, $entity->value, $matches);
+    preg_match(Twitter::VALIDATION_REGEXP, $entity->uri, $matches);
     $response = $this->httpClient->get($matches[0], ['allow_redirects' => FALSE]);
 
     if ($response->getStatusCode() == 302 && ($location = $response->getHeader('location'))) {


### PR DESCRIPTION
And the new formatter provided in the previous commit requires the use of a link field. Changed to `$entity->uri`.
