### PR TITLE
Add string and string_long support to the Twitter embed formatter

### DIFF
--- a/src/Plugin/Field/FieldFormatter/TwitterEmbedFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/TwitterEmbedFormatter.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\media_entity_twitter\Plugin\Field\FieldFormatter;
 
+use Drupal\Core\Field\FieldItemInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\FormatterBase;
 use Drupal\media_entity_twitter\Plugin\MediaEntity\Type\Twitter;
@@ -18,11 +19,32 @@ use Drupal\media_entity_twitter\Plugin\MediaEntity\Type\Twitter;
  *   id = "twitter_embed",
  *   label = @Translation("Twitter embed"),
  *   field_types = {
- *     "link"
+ *     "link", "string", "string_long"
  *   }
  * )
  */
 class TwitterEmbedFormatter extends FormatterBase {
+
+  /**
+   * Extracts the embed code from a field item.
+   *
+   * @param \Drupal\Core\Field\FieldItemInterface $item
+   *   The field item.
+   *
+   * @return string|null
+   *   The embed code, or NULL if the field type is not supported.
+   */
+  protected function getEmbedCode(FieldItemInterface $item) {
+    switch ($item->getFieldDefinition()->getType()) {
+      case 'link':
+        return $item->uri;
+      case 'string':
+      case 'string_long':
+        return $item->value;
+      default:
+        break;
+    }
+  }
 
   /**
    * {@inheritdoc}
@@ -33,7 +55,7 @@ class TwitterEmbedFormatter extends FormatterBase {
       $matches = [];
 
       foreach (Twitter::$validationRegexp as $pattern => $key) {
-        if (preg_match($pattern, $item->uri, $item_matches)) {
+        if (preg_match($pattern, $this->getEmbedCode($item), $item_matches)) {
           $matches[] = $item_matches;
         }
       }


### PR DESCRIPTION
Taking over from @balsama to fix #12.

D.o. issue: https://www.drupal.org/node/2621950
