### PR TITLE
Support dynamic embeds

### DIFF
--- a/js/twitter.js
+++ b/js/twitter.js
@@ -8,7 +8,7 @@
       $('blockquote.twitter-tweet > a', context).each(function () {
         // this === link
         var tweetID = this.href.substr(this.href.lastIndexOf('/') + 1);
-        twttr.createTweet(tweetID, this.parentNode);
+        twttr.widgets.createTweet(tweetID, this.parentNode);
       });
     },
 

--- a/js/twitter.js
+++ b/js/twitter.js
@@ -1,0 +1,26 @@
+(function ($, Drupal) {
+  "use strict";
+
+  Drupal.behaviors.twitterMediaEntity = {
+
+    createTweets: function (context) {
+      // this === window
+      $('blockquote.twitter-tweet > a', context).each(function () {
+        // this === link
+        var tweetID = this.href.substr(this.href.lastIndexOf('/') + 1);
+        twttr.createTweet(tweetID, this.parentNode);
+      });
+    },
+
+    attach: function (context) {
+      if (typeof twttr === 'undefined') {
+        $.getScript('//platform.twitter.com/widgets.js', this.createTweets.bind(window, context));
+      }
+      else {
+        this.createTweets(context);
+      }
+    }
+
+  };
+
+})(jQuery, Drupal);

--- a/media_entity_twitter.libraries.yml
+++ b/media_entity_twitter.libraries.yml
@@ -1,8 +1,4 @@
-twitter.widget:
-  remote: //platform.twitter.com/widgets.js
-  version: " 2.3.0"
-  license:
-    name: MIT
-    url: http://www.opensource.org/licenses/mit-license.php
+integration:
+  version: VERSION
   js:
-    //platform.twitter.com/widgets.js: {type: external, minified: true}
+    'js/twitter.js': {}

--- a/src/Plugin/Field/FieldFormatter/TwitterEmbedFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/TwitterEmbedFormatter.php
@@ -80,7 +80,7 @@ class TwitterEmbedFormatter extends FormatterBase {
     if (!empty($element)) {
       $element['#attached'] = [
         'library' => [
-          'media_entity_twitter/twitter.widget',
+          'media_entity_twitter/integration',
         ],
       ];
     }


### PR DESCRIPTION
At the moment, tweets are not supported when embedding tweet entities into CKEditor, because the twitter_embed formatter attaches Twitter's Widgets library globally. Entity Embed, however, relies on Drupal's behaviors in order to properly attach behavior to embedded entities.

This PR uses a behavior to load the Widgets library from Twitter dynamically, then calls its createTweet method on the relevant elements from the context passed into the behavior. It works for normal page views (/media/1) and tweets embedded in CKEditor. Boo-yah!
