### PR TITLE
Allow validation of strings as embed codes

### DIFF
--- a/src/Plugin/Validation/Constraint/TweetEmbedCodeConstraint.php
+++ b/src/Plugin/Validation/Constraint/TweetEmbedCodeConstraint.php
@@ -15,7 +15,7 @@ use Symfony\Component\Validator\Constraint;
  * @Constraint(
  *   id = "TweetEmbedCode",
  *   label = @Translation("Tweet embed code", context = "Validation"),
- *   type = { "entity", "entity_reference" }
+ *   type = { "entity", "entity_reference", "string", "string_long" }
  * )
  */
 class TweetEmbedCodeConstraint extends Constraint {

--- a/src/Plugin/Validation/Constraint/TweetEmbedCodeConstraintValidator.php
+++ b/src/Plugin/Validation/Constraint/TweetEmbedCodeConstraintValidator.php
@@ -19,13 +19,13 @@ class TweetEmbedCodeConstraintValidator extends ConstraintValidator {
   /**
    * {@inheritdoc}
    */
-  public function validate($entity, Constraint $constraint) {
-    if (!isset($entity)) {
+  public function validate($value, Constraint $constraint) {
+    if (!isset($value)) {
       return;
     }
 
     foreach (Twitter::$validationRegexp as $pattern => $key) {
-      if (preg_match($pattern, $entity->value)) {
+      if (preg_match($pattern, $value->value)) {
         return;
       }
     }

--- a/src/Plugin/Validation/Constraint/TweetVisibleConstraint.php
+++ b/src/Plugin/Validation/Constraint/TweetVisibleConstraint.php
@@ -15,7 +15,7 @@ use Symfony\Component\Validator\Constraint;
  * @Constraint(
  *   id = "TweetVisible",
  *   label = @Translation("Tweet publicly visible", context = "Validation"),
- *   type = { "entity", "entity_reference" }
+ *   type = { "entity", "entity_reference", "string", "string_long" }
  * )
  */
 class TweetVisibleConstraint extends Constraint {

--- a/src/Plugin/Validation/Constraint/TweetVisibleConstraintValidator.php
+++ b/src/Plugin/Validation/Constraint/TweetVisibleConstraintValidator.php
@@ -43,19 +43,18 @@ class TweetVisibleConstraintValidator extends ConstraintValidator implements Con
     return new static($container->get('http_client'));
   }
 
-
   /**
    * {@inheritdoc}
    */
-  public function validate($entity, Constraint $constraint) {
-    if (!isset($entity)) {
+  public function validate($value, Constraint $constraint) {
+    if (!isset($value)) {
       return;
     }
 
     $matches = [];
 
     foreach (Twitter::$validationRegexp as $pattern => $key) {
-      if (preg_match($pattern, $entity->value, $item_matches)) {
+      if (preg_match($pattern, $value->value, $item_matches)) {
         $matches[] = $item_matches;
       }
     }


### PR DESCRIPTION
At the moment, the TweetEmbedCode and TweetVisible validation constraints only support the entity and entity_reference data types, which means they don't support validating plain strings (at least not officially). This is an impediment because it means that a media entity must exist in order to be validated as a tweet. But what if you want to validate a string to check if it's an embed code, _then_ create a media entity?

This PR makes the constraints compatible with string and string_long data values.
