### PR TITLE
Non-static access to Twitter::$validationRegexp

### DIFF
--- a/src/Plugin/MediaEntity/Type/Twitter.php
+++ b/src/Plugin/MediaEntity/Type/Twitter.php
@@ -294,7 +294,7 @@ class Twitter extends MediaTypeBase {
       $source_field = $this->configuration['source_field'];
       if ($media->hasField($source_field)) {
         $property_name = $media->{$source_field}->first()->mainPropertyName();
-        foreach ($this->validationRegexp as $pattern => $key) {
+        foreach (static::$validationRegexp as $pattern => $key) {
           if (preg_match($pattern, $media->{$source_field}->{$property_name}, $matches)) {
             return $matches;
           }


### PR DESCRIPTION
This problem throws a recoverable PHP error and breaks our Travis CI builds over at acquia/lightning. Twitter::$validationRegexp was converted to a public static property, but it looks as if Twitter::matchRegexp() did not get that memo. Fixed here.
