### PR TITLE
Get ride of duplicated createMediaBundle method

### DIFF
--- a/src/Tests/TweetEmbedFormatterTest.php
+++ b/src/Tests/TweetEmbedFormatterTest.php
@@ -46,14 +46,23 @@ class TweetEmbedFormatterTest extends WebTestBase {
    *
    * @var string
    */
-  protected $media_id = 'Twitter';
+  protected $media_id = 'twitter';
+
+  /**
+   * The test media bundle.
+   *
+   * @var \Drupal\media_entity\MediaBundleInterface
+   */
+  protected $testBundle;
 
   /**
    * {@inheritdoc}
    */
   protected function setUp() {
     parent::setUp();
-    $this->testBundle = $this->drupalCreateMediaBundle();
+
+    $bundle['bundle'] = $this->media_id;
+    $this->testBundle = $this->drupalCreateMediaBundle($bundle, 'twitter');
     $this->drupalPlaceBlock('local_actions_block');
     $this->adminUser = $this->drupalCreateUser([
       'administer media',
@@ -76,17 +85,17 @@ class TweetEmbedFormatterTest extends WebTestBase {
   /**
    * Tests adding and editing a link type twitter embed formatter.
    */
-  public function dtestManageLinkFormatter() {
+  public function testManageLinkFormatter() {
     // Test and create one media bundle.
-    $bundle = $this->createMediaBundle();
+    $bundle = $this->testBundle;
 
     // Assert that the media bundle has the expected values before proceeding.
-    $this->drupalGet('admin/structure/media/manage/' . $bundle['id']);
-    $this->assertFieldByName('label', $bundle['label']);
-    $this->assertFieldByName('type', $bundle['type']);
+    $this->drupalGet('admin/structure/media/manage/' . $bundle->id());
+    $this->assertFieldByName('label', $bundle->label());
+    $this->assertFieldByName('type', 'twitter');
 
     // Add and save link settings (Embed code).
-    $this->drupalGet('admin/structure/media/manage/' . $bundle['id'] . '/fields/add-field');
+    $this->drupalGet('admin/structure/media/manage/' . $bundle->id() . '/fields/add-field');
     $edit_conf = [
       'new_storage_type' => 'link',
       'label' => 'Link URL',
@@ -118,15 +127,15 @@ class TweetEmbedFormatterTest extends WebTestBase {
 
     // Test if edit worked and if new field values have been saved as
     // expected.
-    $this->drupalGet('admin/structure/media/manage/' . $bundle['id']);
-    $this->assertFieldByName('label', $bundle['label']);
-    $this->assertFieldByName('type', $bundle['type']);
+    $this->drupalGet('admin/structure/media/manage/' . $bundle->id());
+    $this->assertFieldByName('label', $bundle->label());
+    $this->assertFieldByName('type', 'twitter');
     $this->assertFieldByName('type_configuration[twitter][source_field]', 'field_link_url');
     $this->drupalPostForm(NULL, NULL, t('Save media bundle'));
-    $this->assertText('The media bundle ' . $bundle['label'] . ' has been updated.');
-    $this->assertText('Twitter');
+    $this->assertText('The media bundle ' . $bundle->label() . ' has been updated.');
+    $this->assertText($bundle->label());
 
-    $this->drupalGet('admin/structure/media/manage/' . $bundle['id'] . '/display');
+    $this->drupalGet('admin/structure/media/manage/' . $bundle->id() . '/display');
 
     // Set and save the settings of the new field.
     $edit = [
@@ -137,7 +146,7 @@ class TweetEmbedFormatterTest extends WebTestBase {
     $this->assertText('Your settings have been saved.');
 
     // Create and save the media with an twitter media code.
-    $this->drupalGet('media/add/' . $bundle['id']);
+    $this->drupalGet('media/add/' . $bundle->id());
 
     // Random image from twitter.
     $tweet_url = 'https://twitter.com/RamzyStinson/status/670650348319576064';
@@ -161,15 +170,15 @@ class TweetEmbedFormatterTest extends WebTestBase {
    */
   public function testManageFieldFormatter() {
     // Test and create one media bundle.
-    $bundle = $this->createMediaBundle();
+    $bundle = $this->testBundle;
 
     // Assert that the media bundle has the expected values before proceeding.
-    $this->drupalGet('admin/structure/media/manage/' . $bundle['id']);
-    $this->assertFieldByName('label', $bundle['label']);
-    $this->assertFieldByName('type', $bundle['type']);
+    $this->drupalGet('admin/structure/media/manage/' . $bundle->id());
+    $this->assertFieldByName('label', $bundle->label());
+    $this->assertFieldByName('type', 'twitter');
 
     // Add and save field settings (Embed code).
-    $this->drupalGet('admin/structure/media/manage/' . $bundle['id'] . '/fields/add-field');
+    $this->drupalGet('admin/structure/media/manage/' . $bundle->id() . '/fields/add-field');
     $edit_conf = [
       'new_storage_type' => 'link',
       'label' => 'Tweet URL',
@@ -201,15 +210,15 @@ class TweetEmbedFormatterTest extends WebTestBase {
 
     // Test if edit worked and if new field values have been saved as
     // expected.
-    $this->drupalGet('admin/structure/media/manage/' . $bundle['id']);
-    $this->assertFieldByName('label', $bundle['label']);
-    $this->assertFieldByName('type', $bundle['type']);
+    $this->drupalGet('admin/structure/media/manage/' . $bundle->id());
+    $this->assertFieldByName('label', $bundle->label());
+    $this->assertFieldByName('type', 'twitter');
     $this->assertFieldByName('type_configuration[twitter][source_field]', 'field_tweet_url');
     $this->drupalPostForm(NULL, NULL, t('Save media bundle'));
-    $this->assertText('The media bundle ' . $bundle['label'] . ' has been updated.');
-    $this->assertText('Twitter');
+    $this->assertText('The media bundle ' . $bundle->label() . ' has been updated.');
+    $this->assertText($bundle->label());
 
-    $this->drupalGet('admin/structure/media/manage/' . $bundle['id'] . '/display');
+    $this->drupalGet('admin/structure/media/manage/' . $bundle->id() . '/display');
 
     // Set and save the settings of the new field.
     $edit = [
@@ -220,7 +229,7 @@ class TweetEmbedFormatterTest extends WebTestBase {
     $this->assertText('Your settings have been saved.');
 
     // Create and save the media with an twitter media code.
-    $this->drupalGet('media/add/' . $bundle['id']);
+    $this->drupalGet('media/add/' . $bundle->id());
 
     // Random image from twitter.
     $tweet_url = 'https://twitter.com/RamzyStinson/status/670650348319576064';
@@ -237,32 +246,6 @@ class TweetEmbedFormatterTest extends WebTestBase {
 
     // Assert that the formatter exists on this page.
     $this->assertFieldByXPath('/html/body/div/main/div/div/article/div/div');
-  }
-
-  /**
-   * Creates and tests a new media bundle.
-   *
-   * @return array
-   *   Returns the media bundle fields.
-   */
-  public function createMediaBundle() {
-    // Generates and holds all media bundle fields.
-    $edit = [
-      'id' => strtolower($this->media_id),
-      'label' => $this->media_id,
-      'type' => 'twitter',
-    ];
-
-    // Create new media bundle.
-    $this->drupalPostForm('admin/structure/media/add', $edit, t('Save media bundle'));
-    $this->assertText('The media bundle ' . $this->media_id . ' has been added.');
-
-    // Check if media bundle is successfully created.
-    $this->drupalGet('admin/structure/media');
-    $this->assertResponse(200);
-    $this->assertRaw($edit['label']);
-
-    return $edit;
   }
 
 }


### PR DESCRIPTION
Same as in [media_entity_instagram](https://github.com/drupal-media/media_entity_instagram/pull/20).
In TwitterEmbedFormatterTest we call drupalCreateMediaBundle() from MediaTestTrait plus we have another method that do the same thing.

I have fixed it, but I have hardcoded the assertion for 'type' (media type provider plugin).
If you have any better solution please share your thoughts here :)

PS: I have seen that the two tests here are pretty much the same. I'll create another PR to change one of them to string_long or something different.
