### PR TITLE
Replace 2nd test with string_long

### DIFF
--- a/src/Tests/TweetEmbedFormatterTest.php
+++ b/src/Tests/TweetEmbedFormatterTest.php
@@ -83,9 +83,9 @@ class TweetEmbedFormatterTest extends WebTestBase {
   }
 
   /**
-   * Tests adding and editing a link type twitter embed formatter.
+   * Tests adding and editing a twitter embed formatter.
    */
-  public function testManageLinkFormatter() {
+  public function testManageEmbedFormatter() {
     // Test and create one media bundle.
     $bundle = $this->testBundle;
 
@@ -94,7 +94,7 @@ class TweetEmbedFormatterTest extends WebTestBase {
     $this->assertFieldByName('label', $bundle->label());
     $this->assertFieldByName('type', 'twitter');
 
-    // Add and save link settings (Embed code).
+    // Add and save link field type settings (Embed code).
     $this->drupalGet('admin/structure/media/manage/' . $bundle->id() . '/fields/add-field');
     $edit_conf = [
       'new_storage_type' => 'link',
@@ -110,7 +110,7 @@ class TweetEmbedFormatterTest extends WebTestBase {
     $this->drupalPostForm(NULL, $edit, t('Save field settings'));
     $this->assertText('Updated field ' . $edit_conf['label'] . ' field settings.');
 
-    // Set the new field as required.
+    // Set the new link field type as required.
     $edit = [
       'required' => TRUE,
       'settings[link_type]' => '16',
@@ -119,65 +119,7 @@ class TweetEmbedFormatterTest extends WebTestBase {
     $this->drupalPostForm(NULL, $edit, t('Save settings'));
     $this->assertText('Saved ' . $edit_conf['label'] . ' configuration.');
 
-    // Assert that the new field configuration has been successfully saved.
-    $xpath = $this->xpath('//*[@id="field-link-url"]');
-    $this->assertEqual((string) $xpath[0]->td[0], 'Link URL');
-    $this->assertEqual((string) $xpath[0]->td[1], 'field_link_url');
-    $this->assertEqual((string) $xpath[0]->td[2]->a, 'Link');
-
-    // Test if edit worked and if new field values have been saved as
-    // expected.
-    $this->drupalGet('admin/structure/media/manage/' . $bundle->id());
-    $this->assertFieldByName('label', $bundle->label());
-    $this->assertFieldByName('type', 'twitter');
-    $this->assertFieldByName('type_configuration[twitter][source_field]', 'field_link_url');
-    $this->drupalPostForm(NULL, NULL, t('Save media bundle'));
-    $this->assertText('The media bundle ' . $bundle->label() . ' has been updated.');
-    $this->assertText($bundle->label());
-
-    $this->drupalGet('admin/structure/media/manage/' . $bundle->id() . '/display');
-
-    // Set and save the settings of the new field.
-    $edit = [
-      'fields[field_link_url][label]' => 'above',
-      'fields[field_link_url][type]' => 'link',
-    ];
-    $this->drupalPostForm(NULL, $edit, t('Save'));
-    $this->assertText('Your settings have been saved.');
-
-    // Create and save the media with an twitter media code.
-    $this->drupalGet('media/add/' . $bundle->id());
-
-    // Random image from twitter.
-    $tweet_url = 'https://twitter.com/RamzyStinson/status/670650348319576064';
-
-    $edit = [
-      'name[0][value]' => 'Title',
-      'field_link_url[0][uri]' => $tweet_url,
-    ];
-    $this->drupalPostForm(NULL, $edit, t('Save'));
-
-    // Assert that the media has been successfully saved.
-    $this->assertText('Title');
-    $this->assertText('Link URL');
-
-    // Assert that the link url formatter exists on this page.
-    $this->assertFieldByXPath('/html/body/div/main/div/div/article/div[5]/div[2]/a');
-  }
-
-  /**
-   * Tests adding and editing an embed code type twitter embed formatter.
-   */
-  public function testManageFieldFormatter() {
-    // Test and create one media bundle.
-    $bundle = $this->testBundle;
-
-    // Assert that the media bundle has the expected values before proceeding.
-    $this->drupalGet('admin/structure/media/manage/' . $bundle->id());
-    $this->assertFieldByName('label', $bundle->label());
-    $this->assertFieldByName('type', 'twitter');
-
-    // Add and save field settings (Embed code).
+    // Add and save string_long field type settings (Embed code).
     $this->drupalGet('admin/structure/media/manage/' . $bundle->id() . '/fields/add-field');
     $edit_conf = [
       'new_storage_type' => 'string_long',
@@ -193,20 +135,25 @@ class TweetEmbedFormatterTest extends WebTestBase {
     $this->drupalPostForm(NULL, $edit, t('Save field settings'));
     $this->assertText('Updated field ' . $edit_conf['label'] . ' field settings.');
 
-    // Set the new field as required.
+    // Set the new string_long field type as required.
     $edit = [
       'required' => TRUE,
     ];
     $this->drupalPostForm(NULL, $edit, t('Save settings'));
     $this->assertText('Saved ' . $edit_conf['label'] . ' configuration.');
 
-    // Assert that the new field configuration has been successfully saved.
+    // Assert that the new field types configurations have been successfully saved.
+    $xpath = $this->xpath('//*[@id="field-link-url"]');
+    $this->assertEqual((string) $xpath[0]->td[0], 'Link URL');
+    $this->assertEqual((string) $xpath[0]->td[1], 'field_link_url');
+    $this->assertEqual((string) $xpath[0]->td[2]->a, 'Link');
+
     $xpath = $this->xpath('//*[@id="field-embed-code"]');
     $this->assertEqual((string) $xpath[0]->td[0], 'Embed code');
     $this->assertEqual((string) $xpath[0]->td[1], 'field_embed_code');
     $this->assertEqual((string) $xpath[0]->td[2]->a, 'Text (plain, long)');
 
-    // Test if edit worked and if new field values have been saved as
+    // Test if edit worked and if new fields values have been saved as
     // expected.
     $this->drupalGet('admin/structure/media/manage/' . $bundle->id());
     $this->assertFieldByName('label', $bundle->label());
@@ -218,37 +165,47 @@ class TweetEmbedFormatterTest extends WebTestBase {
 
     $this->drupalGet('admin/structure/media/manage/' . $bundle->id() . '/display');
 
-    // Set and save the settings of the new field.
+    // Set and save the settings of the new field types.
     $edit = [
+      'fields[field_link_url][label]' => 'above',
+      'fields[field_link_url][type]' => 'twitter_embed',
       'fields[field_embed_code][label]' => 'above',
       'fields[field_embed_code][type]' => 'twitter_embed',
     ];
     $this->drupalPostForm(NULL, $edit, t('Save'));
     $this->assertText('Your settings have been saved.');
 
-    // Create and save the media with an twitter media code.
+    // Create and save the media with a twitter media code.
     $this->drupalGet('media/add/' . $bundle->id());
 
+    // Random image url from twitter.
+    $tweet_url = 'https://twitter.com/RamzyStinson/status/670650348319576064';
+
     // Random image from twitter.
-    $tweet_url = '<blockquote class="twitter-tweet" lang="it"><p lang="en" dir="ltr">' .
-                 'Midnight project. I ain&#39;t got no oven. So I improvise making this milo crunchy kek batik. hahahaha ' .
-                 '<a href="https://twitter.com/hashtag/itssomething?src=hash">#itssomething</a> ' .
-                 '<a href="https://t.co/Nvn4Q1v2ae">pic.twitter.com/Nvn4Q1v2ae</a></p>&mdash; Zi (@RamzyStinson) ' .
-                 '<a href="https://twitter.com/RamzyStinson/status/670650348319576064">' .
-                 '28 Novembre 2015</a></blockquote><script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>';
+    $tweet = '<blockquote class="twitter-tweet" lang="it"><p lang="en" dir="ltr">' .
+             'Midnight project. I ain&#39;t got no oven. So I improvise making this milo crunchy kek batik. hahahaha ' .
+             '<a href="https://twitter.com/hashtag/itssomething?src=hash">#itssomething</a> ' .
+             '<a href="https://t.co/Nvn4Q1v2ae">pic.twitter.com/Nvn4Q1v2ae</a></p>&mdash; Zi (@RamzyStinson) ' .
+             '<a href="https://twitter.com/RamzyStinson/status/670650348319576064">' .
+             '28 Novembre 2015</a></blockquote><script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>';
 
     $edit = [
       'name[0][value]' => 'Title',
-      'field_embed_code[0][value]' => $tweet_url,
+      'field_link_url[0][uri]' => $tweet_url,
+      'field_embed_code[0][value]' => $tweet,
     ];
     $this->drupalPostForm(NULL, $edit, t('Save'));
 
     // Assert that the media has been successfully saved.
     $this->assertText('Title');
-    $this->assertText('Embed code');
 
-    // Assert that the formatter exists on this page.
-    $this->assertFieldByXPath('/html/body/div/main/div/div/article/div/div');
+    // Assert that the link url formatter exists on this page.
+    $this->assertText('Link URL');
+    $this->assertFieldByXPath('/html/body/div/main/div/div/article/div[5]/div[2]/blockquote/a');
+
+    // Assert that the string_long code formatter exists on this page.
+    $this->assertText('Embed code');
+    $this->assertFieldByXPath('/html/body/div/main/div/div/article/div[6]/div[2]/blockquote/a');
   }
 
 }

--- a/src/Tests/TweetEmbedFormatterTest.php
+++ b/src/Tests/TweetEmbedFormatterTest.php
@@ -166,7 +166,7 @@ class TweetEmbedFormatterTest extends WebTestBase {
   }
 
   /**
-   * Tests adding and editing a twitter embed formatter.
+   * Tests adding and editing an embed code type twitter embed formatter.
    */
   public function testManageFieldFormatter() {
     // Test and create one media bundle.
@@ -180,9 +180,9 @@ class TweetEmbedFormatterTest extends WebTestBase {
     // Add and save field settings (Embed code).
     $this->drupalGet('admin/structure/media/manage/' . $bundle->id() . '/fields/add-field');
     $edit_conf = [
-      'new_storage_type' => 'link',
-      'label' => 'Tweet URL',
-      'field_name' => 'tweet_url',
+      'new_storage_type' => 'string_long',
+      'label' => 'Embed code',
+      'field_name' => 'embed_code',
     ];
     $this->drupalPostForm(NULL, $edit_conf, t('Save and continue'));
     $this->assertText('These settings apply to the ' . $edit_conf['label'] . ' field everywhere it is used.');
@@ -196,24 +196,22 @@ class TweetEmbedFormatterTest extends WebTestBase {
     // Set the new field as required.
     $edit = [
       'required' => TRUE,
-      'settings[link_type]' => '16',
-      'settings[title]' => '0',
     ];
     $this->drupalPostForm(NULL, $edit, t('Save settings'));
     $this->assertText('Saved ' . $edit_conf['label'] . ' configuration.');
 
     // Assert that the new field configuration has been successfully saved.
-    $xpath = $this->xpath('//*[@id="field-tweet-url"]');
-    $this->assertEqual((string) $xpath[0]->td[0], 'Tweet URL');
-    $this->assertEqual((string) $xpath[0]->td[1], 'field_tweet_url');
-    $this->assertEqual((string) $xpath[0]->td[2]->a, 'Link');
+    $xpath = $this->xpath('//*[@id="field-embed-code"]');
+    $this->assertEqual((string) $xpath[0]->td[0], 'Embed code');
+    $this->assertEqual((string) $xpath[0]->td[1], 'field_embed_code');
+    $this->assertEqual((string) $xpath[0]->td[2]->a, 'Text (plain, long)');
 
     // Test if edit worked and if new field values have been saved as
     // expected.
     $this->drupalGet('admin/structure/media/manage/' . $bundle->id());
     $this->assertFieldByName('label', $bundle->label());
     $this->assertFieldByName('type', 'twitter');
-    $this->assertFieldByName('type_configuration[twitter][source_field]', 'field_tweet_url');
+    $this->assertFieldByName('type_configuration[twitter][source_field]', 'field_embed_code');
     $this->drupalPostForm(NULL, NULL, t('Save media bundle'));
     $this->assertText('The media bundle ' . $bundle->label() . ' has been updated.');
     $this->assertText($bundle->label());
@@ -222,8 +220,8 @@ class TweetEmbedFormatterTest extends WebTestBase {
 
     // Set and save the settings of the new field.
     $edit = [
-      'fields[field_tweet_url][label]' => 'above',
-      'fields[field_tweet_url][type]' => 'twitter_embed',
+      'fields[field_embed_code][label]' => 'above',
+      'fields[field_embed_code][type]' => 'twitter_embed',
     ];
     $this->drupalPostForm(NULL, $edit, t('Save'));
     $this->assertText('Your settings have been saved.');
@@ -232,17 +230,22 @@ class TweetEmbedFormatterTest extends WebTestBase {
     $this->drupalGet('media/add/' . $bundle->id());
 
     // Random image from twitter.
-    $tweet_url = 'https://twitter.com/RamzyStinson/status/670650348319576064';
+    $tweet_url = '<blockquote class="twitter-tweet" lang="it"><p lang="en" dir="ltr">' .
+                 'Midnight project. I ain&#39;t got no oven. So I improvise making this milo crunchy kek batik. hahahaha ' .
+                 '<a href="https://twitter.com/hashtag/itssomething?src=hash">#itssomething</a> ' .
+                 '<a href="https://t.co/Nvn4Q1v2ae">pic.twitter.com/Nvn4Q1v2ae</a></p>&mdash; Zi (@RamzyStinson) ' .
+                 '<a href="https://twitter.com/RamzyStinson/status/670650348319576064">' .
+                 '28 Novembre 2015</a></blockquote><script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>';
 
     $edit = [
       'name[0][value]' => 'Title',
-      'field_tweet_url[0][uri]' => $tweet_url,
+      'field_embed_code[0][value]' => $tweet_url,
     ];
     $this->drupalPostForm(NULL, $edit, t('Save'));
 
     // Assert that the media has been successfully saved.
     $this->assertText('Title');
-    $this->assertText('Tweet URL');
+    $this->assertText('Embed code');
 
     // Assert that the formatter exists on this page.
     $this->assertFieldByXPath('/html/body/div/main/div/div/article/div/div');


### PR DESCRIPTION
As I mentioned in [PR#20](https://github.com/drupal-media/media_entity_twitter/pull/20) we have two tests that are pretty much the same. 

Here I replaced the second one with string_long.

Issue in [d.o](https://www.drupal.org/node/2631772).
